### PR TITLE
add audit with state & yalc to test locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v4.0.5
+
+Changes
+
+- Separate state from Audit base class. Now we have a AuditWithState which is the correct one to use for each request, to not share state between requests.
+- Use AuditWithState instead of Audit in @alanszp/express
+
+-------------
+
 ## v4.0.4
 
 Changes

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "pack-all": "rm -rf tgzs/ && mkdir tgzs/ && ls -1 packages | xargs -tI % sh -c 'cd ./packages/%; yarn pack; mv ./*.tgz ../../tgzs'"
   },
   "dependencies": {
-    "lerna": "^4.0.0"
+    "lerna": "^4.0.0",
+    "yalc": "^1.0.0-pre.53"
   }
 }

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -15,7 +15,8 @@
     "compile": "rm -rf ./dist && tsc --declaration",
     "compile-watch": "tsc -w",
     "build": "yarn run compile",
-    "prepack": "yarn run build"
+    "prepack": "yarn run build",
+    "yalc-publish": "yarn run yalc publish"
   },
   "dependencies": {
     "@alanszp/errors": "^4.0.0",

--- a/packages/audit/src/audit.ts
+++ b/packages/audit/src/audit.ts
@@ -1,41 +1,31 @@
 import { ILogger, LogType } from "@alanszp/logger";
-import { difference, merge } from "lodash";
+import { difference } from "lodash";
 import { AuditBody, REQUIRED_FIELDS } from ".";
+import { AuditWithState } from "./auditWithState";
 import { MissingAuditFieldsError } from "./errors/MissingAuditFieldsError";
 
 export class Audit {
   public logger: ILogger;
 
-  public additions: Partial<AuditBody>;
-
   constructor(logger: ILogger) {
     this.logger = logger;
-    this.additions = {};
   }
 
-  public log(body: Partial<AuditBody>): void {
-    const completeBody = this.merge(body);
-
-    const missingFields = difference(
-      REQUIRED_FIELDS,
-      Object.keys(completeBody)
-    );
+  public log(body: AuditBody): void {
+    const missingFields = difference(REQUIRED_FIELDS, Object.keys(body));
 
     if (missingFields.length > 0) {
       throw new MissingAuditFieldsError(missingFields);
     }
 
-    const action = completeBody.action as string;
-    delete completeBody.action;
-
-    this.logger.info(action, { log_type: LogType.AUDIT, ...completeBody });
+    this.logger.info(body.action, {
+      log_type: LogType.AUDIT,
+      ...body,
+      action: undefined,
+    });
   }
 
-  public add(body: Partial<AuditBody>): void {
-    this.additions = this.merge(body);
-  }
-
-  public merge(body: Partial<AuditBody>): Partial<AuditBody> {
-    return merge(this.additions, body);
+  public withState(): AuditWithState {
+    return new AuditWithState(this);
   }
 }

--- a/packages/audit/src/auditWithState.ts
+++ b/packages/audit/src/auditWithState.ts
@@ -1,0 +1,27 @@
+import { merge } from "lodash";
+import { AuditBody } from "./interfaces";
+import { Audit } from "./audit";
+
+export class AuditWithState {
+  public audit: Audit;
+
+  public additions: Partial<AuditBody>;
+
+  constructor(audit: Audit) {
+    this.audit = audit;
+    this.additions = {};
+  }
+
+  public log(body: Partial<AuditBody>): void {
+    const completeBody = this.merge(body) as AuditBody;
+    this.audit.log(completeBody);
+  }
+
+  public add(body: Partial<AuditBody>): void {
+    this.additions = this.merge(body);
+  }
+
+  public merge(body: Partial<AuditBody>): Partial<AuditBody> {
+    return merge(this.additions, body);
+  }
+}

--- a/packages/audit/src/index.ts
+++ b/packages/audit/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./factory";
 export * from "./audit";
+export * from "./auditWithState";
 export * from "./interfaces";
 export * from "./errors";

--- a/packages/axios-node/package.json
+++ b/packages/axios-node/package.json
@@ -15,7 +15,8 @@
     "compile": "rm -rf ./dist && tsc --declaration",
     "compile-watch": "tsc -w",
     "build": "yarn run compile",
-    "prepack": "yarn run build"
+    "prepack": "yarn run build",
+    "yalc-publish": "yarn run yalc publish"
   },
   "dependencies": {
     "@alanszp/errors": "^4.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,7 @@
     "compile": "rm -rf ./dist && tsc --declaration",
     "compile-watch": "tsc -w",
     "build": "yarn run compile",
-    "prepack": "yarn run build"
+    "prepack": "yarn run build",
+    "yalc-publish": "yarn run yalc publish"
   }
 }

--- a/packages/datadog-client/package.json
+++ b/packages/datadog-client/package.json
@@ -15,7 +15,8 @@
     "compile": "rm -rf ./dist && tsc --declaration",
     "compile-watch": "tsc -w",
     "build": "yarn run compile",
-    "prepack": "yarn run build"
+    "prepack": "yarn run build",
+    "yalc-publish": "yarn run yalc publish"
   },
   "dependencies": {
     "datadog-metrics": "^0.8.1"

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -15,7 +15,8 @@
     "compile": "rm -rf ./dist && tsc --declaration",
     "compile-watch": "tsc -w",
     "build": "yarn run compile",
-    "prepack": "yarn run build"
+    "prepack": "yarn run build",
+    "yalc-publish": "yarn run yalc publish"
   },
   "devDependencies": {
     "@types/node": "^15.12.3",

--- a/packages/express-common-fn/package.json
+++ b/packages/express-common-fn/package.json
@@ -15,7 +15,8 @@
     "compile": "rm -rf ./dist && tsc --declaration",
     "compile-watch": "tsc -w",
     "build": "yarn run compile",
-    "prepack": "yarn run build"
+    "prepack": "yarn run build",
+    "yalc-publish": "yarn run yalc publish"
   },
   "dependencies": {
     "@alanszp/errors": "^4.0.0",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -15,7 +15,8 @@
     "compile": "rm -rf ./dist && tsc --declaration",
     "compile-watch": "tsc -w",
     "build": "yarn run compile",
-    "prepack": "yarn run build"
+    "prepack": "yarn run build",
+    "yalc-publish": "yarn run yalc publish"
   },
   "peerDependencies": {
     "express": "^4.17.1"

--- a/packages/express/src/middlewares/extraContext.ts
+++ b/packages/express/src/middlewares/extraContext.ts
@@ -4,8 +4,10 @@ import { ILogger } from "@alanszp/logger";
 import { Audit } from "@alanszp/audit";
 import { AsyncLocalStorage } from "async_hooks";
 import { appIdentifier } from "../helpers/appIdentifier";
+import { AuditWithState } from "@alanszp/audit/dist/auditWithState";
 
 export interface RequestSharedContext {
+  audit: AuditWithState;
   logger: ILogger;
   lifecycleId: string;
   lifecycleChain: string;
@@ -34,14 +36,17 @@ export function createExtraContext(baseLogger: ILogger, audit: Audit) {
         lch: lifecycleChain,
       });
 
+      const auditWithState = audit.withState();
+
       req.context.authenticated = [];
       req.context.lifecycleId = lifecycleId;
       req.context.lifecycleChain = lifecycleChain;
       req.context.log = logger;
-      req.context.audit = audit;
+      req.context.audit = auditWithState;
 
       requestSharedContext.run(
         {
+          audit: auditWithState,
           logger,
           lifecycleId,
           lifecycleChain,

--- a/packages/express/src/types/custom.d.ts
+++ b/packages/express/src/types/custom.d.ts
@@ -1,5 +1,5 @@
 import { ILogger } from "@alanszp/logger";
-import { Audit } from "@alanszp/audit";
+import { AuditWithState } from "@alanszp/audit";
 import { JWTUser } from "@alanszp/jwt";
 import { AuthMethod } from "./AuthMethod";
 
@@ -11,7 +11,7 @@ declare global {
         lifecycleChain: string;
         authenticated: AuthMethod[];
         log: ILogger;
-        audit: Audit;
+        audit: AuditWithState;
         jwtUser?: JWTUser;
       };
     }

--- a/packages/jwt/package.json
+++ b/packages/jwt/package.json
@@ -15,7 +15,8 @@
     "compile": "rm -rf ./dist && tsc --declaration",
     "compile-watch": "tsc -w",
     "build": "yarn run compile",
-    "prepack": "yarn run build"
+    "prepack": "yarn run build",
+    "yalc-publish": "yarn run yalc publish"
   },
   "devDependencies": {
     "@types/node": "^15.12.3",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -15,7 +15,8 @@
     "compile": "rm -rf ./dist && tsc --declaration",
     "compile-watch": "tsc -w",
     "build": "yarn run compile",
-    "prepack": "yarn run build"
+    "prepack": "yarn run build",
+    "yalc-publish": "yarn run yalc publish"
   },
   "peerDependencies": {
     "@alanszp/axios-node": "^4.0.0",

--- a/packages/typeorm/package.json
+++ b/packages/typeorm/package.json
@@ -15,7 +15,8 @@
     "compile": "rm -rf ./dist && tsc --declaration",
     "compile-watch": "tsc -w",
     "build": "yarn run compile",
-    "prepack": "yarn run build"
+    "prepack": "yarn run build",
+    "yalc-publish": "yarn run yalc publish"
   },
   "devDependencies": {
     "@alanszp/logger": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2169,6 +2169,15 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+fs-extra@^8.0.1:
+  version "8.1.0"
+  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
@@ -2527,6 +2536,11 @@ ignore-walk@^3.0.3:
   dependencies:
     minimatch "^3.0.4"
 
+ignore@^5.0.4:
+  version "5.2.0"
+  resolved "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
+  integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
+
 ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
@@ -2585,6 +2599,11 @@ ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
   version "1.3.8"
   resolved "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
+
+ini@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
+  integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
 
 init-package-json@^2.0.2:
   version "2.0.4"
@@ -2891,6 +2910,13 @@ json5@^2.1.1:
   integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
   dependencies:
     minimist "^1.2.5"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsonfile@^6.0.1:
   version "6.1.0"
@@ -3518,7 +3544,7 @@ npm-package-arg@^8.0.0, npm-package-arg@^8.0.1, npm-package-arg@^8.1.0, npm-pack
     semver "^7.3.4"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^2.1.4:
+npm-packlist@^2.1.4, npm-packlist@^2.1.5:
   version "2.2.2"
   resolved "https://registry.npmjs.org/npm-packlist/-/npm-packlist-2.2.2.tgz#076b97293fa620f632833186a7a8f65aaa6148c8"
   integrity sha512-Jt01acDvJRhJGthnUJVF/w6gumWOZxO7IkpY/lsX9//zqQgnF7OJaxgQXcerd4uQOLu7W5bkb4mChL9mdfm+Zg==
@@ -4976,6 +5002,11 @@ universal-user-agent@^6.0.0:
   resolved "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
   integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
 
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
 universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
@@ -5191,6 +5222,20 @@ y18n@^5.0.5:
   resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
+yalc@^1.0.0-pre.53:
+  version "1.0.0-pre.53"
+  resolved "https://registry.npmjs.org/yalc/-/yalc-1.0.0-pre.53.tgz#c51db2bb924a6908f4cb7e82af78f7e5606810bc"
+  integrity sha512-tpNqBCpTXplnduzw5XC+FF8zNJ9L/UXmvQyyQj7NKrDNavbJtHvzmZplL5ES/RCnjX7JR7W9wz5GVDXVP3dHUQ==
+  dependencies:
+    chalk "^4.1.0"
+    detect-indent "^6.0.0"
+    fs-extra "^8.0.1"
+    glob "^7.1.4"
+    ignore "^5.0.4"
+    ini "^2.0.0"
+    npm-packlist "^2.1.5"
+    yargs "^16.1.1"
+
 yallist@^3.0.0, yallist@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
@@ -5233,7 +5278,7 @@ yargs-parser@^20.2.2, yargs-parser@^20.2.3:
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
-yargs@^16.0.0, yargs@^16.2.0:
+yargs@^16.0.0, yargs@^16.1.1, yargs@^16.2.0:
   version "16.2.0"
   resolved "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==


### PR DESCRIPTION
Tenemos que hacer esto del AuditWithState, porque antes el estado se guardaba de forma global, cosa que si un request seteaba una prop, el siguiente request la tenia habilitada esa prop y claramente esta muy mal.

Ahora podes usar el audit (sin state) y tambien podes crear un audit con state, pero que va a vivir en el contexto que vos lo manejes