### PR TITLE
Small changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Changes
 
-- All middlewares exposed will be setting the request param as `Request<any>` to avoid type collision with other middlewares.g
+- All middlewares exposed will be setting the request param as `Request<any>` to avoid type collision with other middlewares.
 - New `CommonMetadataKeys`: `query` to save all query related params.
 
 -------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v4.0.6
+
+Changes
+
+- All middlewares exposed will be setting the request param as `Request<any>` to avoid type collision with other middlewares.g
+- New `CommonMetadataKeys`: `query` to save all query related params.
+
+-------------
+
 ## v4.0.5
 
 Changes

--- a/packages/audit/src/interfaces.ts
+++ b/packages/audit/src/interfaces.ts
@@ -2,6 +2,7 @@ export enum CommonMetadataKeys {
   EMPLOYEE_ID = "employee_id",
   EMPLOYEE_IDS = "employee_ids",
   CHANGES = "changes",
+  QUERY = "query",
 }
 
 export interface Metadata {

--- a/packages/express/src/middlewares/accessLogger.ts
+++ b/packages/express/src/middlewares/accessLogger.ts
@@ -3,7 +3,7 @@ import { LogType } from "@alanszp/logger";
 import { getIp } from "../helpers/getIp";
 
 export function accessLogger(
-  req: Request,
+  req: Request<any>,
   res: Response,
   next: NextFunction
 ): void {

--- a/packages/express/src/middlewares/auditLog.ts
+++ b/packages/express/src/middlewares/auditLog.ts
@@ -12,7 +12,7 @@ export type AuditBodyModifier = (
  */
 export function auditLog(action: string, bodyModifier?: AuditBodyModifier) {
   return function writeAuditLogMiddleware(
-    req: Request,
+    req: Request<any>,
     res: Response,
     next: NextFunction
   ): void {

--- a/packages/express/src/middlewares/authWithJWT.ts
+++ b/packages/express/src/middlewares/authWithJWT.ts
@@ -17,7 +17,7 @@ function parseAuthorizationHeader(
 
 export function createAuthWithJWT(publicKey: string, options?: VerifyOptions) {
   return async function authWithJwt(
-    req: Request,
+    req: Request<any>,
     res: Response,
     next: NextFunction
   ): Promise<void> {

--- a/packages/express/src/middlewares/authedForOrg.ts
+++ b/packages/express/src/middlewares/authedForOrg.ts
@@ -8,7 +8,7 @@ function response401(res: Response): void {
 }
 
 export function authForOrg(
-  req: Request,
+  req: Request<any>,
   res: Response,
   next: NextFunction
 ): void {

--- a/packages/express/src/middlewares/extraContext.ts
+++ b/packages/express/src/middlewares/extraContext.ts
@@ -18,7 +18,7 @@ export function createExtraContext(baseLogger: ILogger, audit: Audit) {
   return {
     requestSharedContext,
     extraContext: function extraContext(
-      req: Request,
+      req: Request<any>,
       _res: Response,
       next: NextFunction
     ): void {

--- a/packages/express/src/middlewares/hasRoles.ts
+++ b/packages/express/src/middlewares/hasRoles.ts
@@ -9,8 +9,8 @@ function response401(res: Response): void {
 
 export function hasRoles(
   roles: string | string[]
-): (req: Request<unknown>, res: Response, next: NextFunction) => void {
-  return (req: Request<unknown>, res: Response, next: NextFunction) => {
+): (req: Request<any>, res: Response, next: NextFunction) => void {
+  return (req: Request<any>, res: Response, next: NextFunction) => {
     const { jwtUser } = req.context;
     if (!jwtUser) {
       return response401(res);

--- a/packages/express/src/middlewares/jsonBodyParser.ts
+++ b/packages/express/src/middlewares/jsonBodyParser.ts
@@ -6,7 +6,7 @@ import { errorView } from "../views/errorView";
 export function jsonBodyParser(options?: OptionsJson) {
   const bodyParser = json(options);
   return function jsonBodyParserMiddleware(
-    req: Request,
+    req: Request<any>,
     res: Response,
     next: NextFunction
   ): void {

--- a/packages/express/src/middlewares/returnNotFound.ts
+++ b/packages/express/src/middlewares/returnNotFound.ts
@@ -3,7 +3,7 @@ import { NotFoundError } from "@alanszp/errors";
 import { errorView } from "../views/errorView";
 
 export function returnNotFound(
-  _req: Request,
+  _req: Request<any>,
   res: Response,
   _next: NextFunction
 ): void {


### PR DESCRIPTION
- All middlewares exposed will be setting the request param as `Request<any>` to avoid type collision with other middlewares.g
- New `CommonMetadataKeys`: `query` to save all query related params.