### PR TITLE
Add API KEY logic for eventbridge requests

### DIFF
--- a/packages/express/babel.config.js
+++ b/packages/express/babel.config.js
@@ -1,0 +1,7 @@
+// Used by Jest
+module.exports = {
+  presets: [
+    ["@babel/preset-env", { targets: { node: "current" } }],
+    "@babel/preset-typescript",
+  ],
+};

--- a/packages/express/jest.config.js
+++ b/packages/express/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  collectCoverageFrom: ["src/**/*.{js,jsx,ts,tsx}"],
+  roots: ["<rootDir>/src/"],
+  clearMocks: true,
+  resetMocks: true,
+  testEnvironment: "node",
+  moduleNameMapper: {
+    "@/(.*)": "<rootDir>/src/$1",
+  },
+};

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "compile": "rm -rf ./dist && tsc --declaration",
     "compile-watch": "tsc -w",
+    "test": "TZ=Etc/UTC jest",
     "build": "yarn run compile",
     "prepack": "yarn run build",
     "yalc-publish": "yarn run yalc publish"
@@ -24,8 +25,15 @@
   "devDependencies": {
     "@types/body-parser": "^1.19.1",
     "@types/express": "^4.17.12",
+    "@types/jest": "^28.1.8",
     "@types/lodash": "^4.14.170",
     "@types/node": "^15.12.3",
+    "@types/rosie": "^0.0.40",
+    "babel-jest": "^29.0.0",
+    "eslint-plugin-jest": "^26.8.7",
+    "faker": "^6.6.6",
+    "jest": "^29.0.0",
+    "rosie": "^2.1.0",
     "ts-node": "^10.0.0",
     "tslint": "^6.1.3",
     "typescript": "^4.3.4"

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -28,12 +28,9 @@
     "@types/jest": "^28.1.8",
     "@types/lodash": "^4.14.170",
     "@types/node": "^15.12.3",
-    "@types/rosie": "^0.0.40",
     "babel-jest": "^29.0.0",
     "eslint-plugin-jest": "^26.8.7",
-    "faker": "^6.6.6",
     "jest": "^29.0.0",
-    "rosie": "^2.1.0",
     "ts-node": "^10.0.0",
     "tslint": "^6.1.3",
     "typescript": "^4.3.4"

--- a/packages/express/src/helpers/now.ts
+++ b/packages/express/src/helpers/now.ts
@@ -1,0 +1,3 @@
+export function now(): Date {
+  return new Date();
+}

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -4,7 +4,7 @@ export * from "./middlewares/auditLog";
 export * from "./middlewares/accessLogger";
 export * from "./middlewares/authedForOrg";
 export * from "./middlewares/createContext";
-export * from "./middlewares/authWithJWT";
+export * from "./middlewares/authenticateUser";
 export * from "./middlewares/returnInternalServerError";
 export * from "./middlewares/returnNotFound";
 export * from "./middlewares/jsonBodyParser";

--- a/packages/express/src/middlewares/authenticateUser.test.ts
+++ b/packages/express/src/middlewares/authenticateUser.test.ts
@@ -1,0 +1,247 @@
+import { AuthMethods, createAuthContext } from "./authenticateUser";
+import { verifyJWT } from "@alanszp/jwt";
+import {
+  mockNext,
+  mockRequest,
+  mockResponse,
+} from "../test/mocks/expressMocks";
+import { laraJwtUserMock, userJwtUserMock } from "../test/mocks/jwtUserMocks";
+import {
+  apiKeyAuthOptions,
+  bothMethodsAuthOptions,
+  jwtAuthOptions,
+  verifyOptions,
+} from "../test/mocks/authOptionsMocks";
+
+jest.mock("@alanszp/jwt");
+
+describe("AuthenticateUser", () => {
+  describe("authentication with only JWT", () => {
+    describe("when jwt verifies correctly", () => {
+      it("should authenticate correctly and call next", async () => {
+        (verifyJWT as jest.Mock).mockResolvedValueOnce(userJwtUserMock);
+
+        const req = mockRequest("Bearer token");
+        const res = mockResponse();
+        const next = mockNext();
+
+        await createAuthContext(jwtAuthOptions)([AuthMethods.JWT])(
+          req,
+          res,
+          next
+        );
+
+        expect(verifyJWT).toBeCalledWith("publicKey", "token", verifyOptions);
+        expect(res.status).toHaveBeenCalledTimes(0);
+        expect(res.json).toHaveBeenCalledTimes(0);
+        expect(req.context.jwtUser).toMatchObject(userJwtUserMock);
+        expect(req.context.authenticated).toStrictEqual(["jwt"]);
+        expect(next).toBeCalledWith();
+      });
+    });
+
+    describe("when jwt verifies incorrectly", () => {
+      it("should not authenticate, should not call next, and it should return 401", async () => {
+        (verifyJWT as jest.Mock).mockResolvedValueOnce(undefined);
+
+        const req = mockRequest("Bearer token");
+        const res = mockResponse();
+        const next = mockNext();
+
+        await createAuthContext(jwtAuthOptions)([AuthMethods.JWT])(
+          req,
+          res,
+          next
+        );
+
+        expect(verifyJWT).toBeCalledWith("publicKey", "token", verifyOptions);
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledTimes(1);
+        expect(req.context.jwtUser).toBe(undefined);
+        expect(req.context.authenticated).toEqual([]);
+        expect(next).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    describe("when jwt doesn't exist", () => {
+      it("should not verify JWT, should not authenticate, should not call next, and it should return 401", async () => {
+        const req = mockRequest("aa");
+        const res = mockResponse();
+        const next = mockNext();
+
+        await createAuthContext(jwtAuthOptions)([AuthMethods.JWT])(
+          req,
+          res,
+          next
+        );
+
+        expect(verifyJWT).toHaveBeenCalledTimes(0);
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledTimes(1);
+        expect(req.context.jwtUser).toBe(undefined);
+        expect(req.context.authenticated).toEqual([]);
+        expect(next).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+
+  describe("authentication with only API KEY", () => {
+    describe("when api key verifies correctly", () => {
+      it("should authenticate correctly and call next", async () => {
+        const req = mockRequest("token");
+        const res = mockResponse();
+        const next = mockNext();
+
+        await createAuthContext(apiKeyAuthOptions)([AuthMethods.API_KEY])(
+          req,
+          res,
+          next
+        );
+
+        expect(verifyJWT).toHaveBeenCalledTimes(0);
+        expect(res.status).toHaveBeenCalledTimes(0);
+        expect(res.json).toHaveBeenCalledTimes(0);
+        expect(req.context.jwtUser).toMatchObject(laraJwtUserMock);
+        expect(req.context.authenticated).toStrictEqual(["api_key"]);
+        expect(next).toBeCalledWith();
+      });
+    });
+
+    describe("when api key verifies incorrectly", () => {
+      it("should not authenticate, should not call next, and it should return 401", async () => {
+        const req = mockRequest("invalidToken");
+        const res = mockResponse();
+        const next = mockNext();
+
+        await createAuthContext(apiKeyAuthOptions)([AuthMethods.API_KEY])(
+          req,
+          res,
+          next
+        );
+
+        expect(verifyJWT).toHaveBeenCalledTimes(0);
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledTimes(1);
+        expect(req.context.jwtUser).toBe(undefined);
+        expect(req.context.authenticated).toEqual([]);
+        expect(next).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    describe("when api key doesn't exist", () => {
+      it("should not verify api key, should not authenticate, should not call next, and it should return 401", async () => {
+        const req = mockRequest(undefined as any);
+        const res = mockResponse();
+        const next = mockNext();
+
+        await createAuthContext(apiKeyAuthOptions)([AuthMethods.API_KEY])(
+          req,
+          res,
+          next
+        );
+
+        expect(verifyJWT).toHaveBeenCalledTimes(0);
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledTimes(1);
+        expect(req.context.jwtUser).toBe(undefined);
+        expect(req.context.authenticated).toEqual([]);
+        expect(next).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+
+  describe("authentication with JWT and API KEY", () => {
+    describe("when api key verifies correctly", () => {
+      it("should authenticate correctly and call next", async () => {
+        const req = mockRequest("token");
+        const res = mockResponse();
+        const next = mockNext();
+
+        await createAuthContext(bothMethodsAuthOptions)([
+          AuthMethods.API_KEY,
+          AuthMethods.JWT,
+        ])(req, res, next);
+
+        expect(verifyJWT).toHaveBeenCalledTimes(0);
+        expect(res.status).toHaveBeenCalledTimes(0);
+        expect(res.json).toHaveBeenCalledTimes(0);
+        expect(req.context.jwtUser).toMatchObject(laraJwtUserMock);
+        expect(req.context.authenticated).toStrictEqual(["api_key"]);
+        expect(next).toHaveBeenCalledWith();
+      });
+    });
+
+    describe("when api key verifies incorrectly", () => {
+      it("should not authenticate, should not call next, and it should return 401", async () => {
+        const req = mockRequest("invalidToken");
+        const res = mockResponse();
+        const next = mockNext();
+
+        await createAuthContext(bothMethodsAuthOptions)([
+          AuthMethods.API_KEY,
+          AuthMethods.JWT,
+        ])(req, res, next);
+
+        expect(verifyJWT).toHaveBeenCalledTimes(0);
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledTimes(1);
+        expect(req.context.jwtUser).toBe(undefined);
+        expect(req.context.authenticated).toEqual([]);
+        expect(next).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    describe("when jwt verifies correctly", () => {
+      it("should authenticate correctly and call next", async () => {
+        (verifyJWT as jest.Mock).mockResolvedValueOnce(userJwtUserMock);
+
+        const req = mockRequest("Bearer token");
+        const res = mockResponse();
+        const next = mockNext();
+
+        await createAuthContext(bothMethodsAuthOptions)([
+          AuthMethods.API_KEY,
+          AuthMethods.JWT,
+        ])(req, res, next);
+
+        expect(verifyJWT).toBeCalledWith("publicKey", "token", {
+          issuer: "issuer",
+          audience: "audience",
+        });
+        expect(res.status).toHaveBeenCalledTimes(0);
+        expect(res.json).toHaveBeenCalledTimes(0);
+
+        expect(req.context.jwtUser).toMatchObject(userJwtUserMock);
+
+        expect(req.context.authenticated).toStrictEqual(["jwt"]);
+
+        expect(next).toHaveBeenCalledWith();
+      });
+    });
+
+    describe("when jwt verifies incorrectly", () => {
+      it("should not authenticate, should not call next, and it should return 401", async () => {
+        (verifyJWT as jest.Mock).mockResolvedValueOnce(undefined);
+
+        const req = mockRequest("Bearer token");
+        const res = mockResponse();
+        const next = mockNext();
+
+        await createAuthContext(bothMethodsAuthOptions)([
+          AuthMethods.API_KEY,
+          AuthMethods.JWT,
+        ])(req, res, next);
+
+        expect(verifyJWT).toBeCalledWith("publicKey", "token", {
+          issuer: "issuer",
+          audience: "audience",
+        });
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledTimes(1);
+        expect(req.context.jwtUser).toBe(undefined);
+        expect(req.context.authenticated).toEqual([]);
+        expect(next).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+});

--- a/packages/express/src/middlewares/authenticateUser.test.ts
+++ b/packages/express/src/middlewares/authenticateUser.test.ts
@@ -151,96 +151,252 @@ describe("AuthenticateUser", () => {
   });
 
   describe("authentication with JWT and API KEY", () => {
-    describe("when api key verifies correctly", () => {
-      it("should authenticate correctly and call next", async () => {
-        const req = mockRequest("token");
-        const res = mockResponse();
-        const next = mockNext();
+    describe("using both methods", () => {
+      describe("when api key verifies correctly", () => {
+        it("should authenticate correctly and call next", async () => {
+          const req = mockRequest("token");
+          const res = mockResponse();
+          const next = mockNext();
 
-        await createAuthContext(bothMethodsAuthOptions)([
-          AuthMethods.API_KEY,
-          AuthMethods.JWT,
-        ])(req, res, next);
+          await createAuthContext(bothMethodsAuthOptions)([
+            AuthMethods.API_KEY,
+            AuthMethods.JWT,
+          ])(req, res, next);
 
-        expect(verifyJWT).toHaveBeenCalledTimes(0);
-        expect(res.status).toHaveBeenCalledTimes(0);
-        expect(res.json).toHaveBeenCalledTimes(0);
-        expect(req.context.jwtUser).toMatchObject(laraJwtUserMock);
-        expect(req.context.authenticated).toStrictEqual(["api_key"]);
-        expect(next).toHaveBeenCalledWith();
-      });
-    });
-
-    describe("when api key verifies incorrectly", () => {
-      it("should not authenticate, should not call next, and it should return 401", async () => {
-        const req = mockRequest("invalidToken");
-        const res = mockResponse();
-        const next = mockNext();
-
-        await createAuthContext(bothMethodsAuthOptions)([
-          AuthMethods.API_KEY,
-          AuthMethods.JWT,
-        ])(req, res, next);
-
-        expect(verifyJWT).toHaveBeenCalledTimes(0);
-        expect(res.status).toHaveBeenCalledWith(401);
-        expect(res.json).toHaveBeenCalledTimes(1);
-        expect(req.context.jwtUser).toBe(undefined);
-        expect(req.context.authenticated).toEqual([]);
-        expect(next).toHaveBeenCalledTimes(0);
-      });
-    });
-
-    describe("when jwt verifies correctly", () => {
-      it("should authenticate correctly and call next", async () => {
-        (verifyJWT as jest.Mock).mockResolvedValueOnce(userJwtUserMock);
-
-        const req = mockRequest("Bearer token");
-        const res = mockResponse();
-        const next = mockNext();
-
-        await createAuthContext(bothMethodsAuthOptions)([
-          AuthMethods.API_KEY,
-          AuthMethods.JWT,
-        ])(req, res, next);
-
-        expect(verifyJWT).toBeCalledWith("publicKey", "token", {
-          issuer: "issuer",
-          audience: "audience",
+          expect(verifyJWT).toHaveBeenCalledTimes(0);
+          expect(res.status).toHaveBeenCalledTimes(0);
+          expect(res.json).toHaveBeenCalledTimes(0);
+          expect(req.context.jwtUser).toMatchObject(laraJwtUserMock);
+          expect(req.context.authenticated).toStrictEqual(["api_key"]);
+          expect(next).toHaveBeenCalledWith();
         });
-        expect(res.status).toHaveBeenCalledTimes(0);
-        expect(res.json).toHaveBeenCalledTimes(0);
+      });
 
-        expect(req.context.jwtUser).toMatchObject(userJwtUserMock);
+      describe("when api key verifies incorrectly", () => {
+        it("should not authenticate, should not call next, and it should return 401", async () => {
+          const req = mockRequest("invalidToken");
+          const res = mockResponse();
+          const next = mockNext();
 
-        expect(req.context.authenticated).toStrictEqual(["jwt"]);
+          await createAuthContext(bothMethodsAuthOptions)([
+            AuthMethods.API_KEY,
+            AuthMethods.JWT,
+          ])(req, res, next);
 
-        expect(next).toHaveBeenCalledWith();
+          expect(verifyJWT).toHaveBeenCalledTimes(0);
+          expect(res.status).toHaveBeenCalledWith(401);
+          expect(res.json).toHaveBeenCalledTimes(1);
+          expect(req.context.jwtUser).toBe(undefined);
+          expect(req.context.authenticated).toEqual([]);
+          expect(next).toHaveBeenCalledTimes(0);
+        });
+      });
+
+      describe("when jwt verifies correctly", () => {
+        it("should authenticate correctly and call next", async () => {
+          (verifyJWT as jest.Mock).mockResolvedValueOnce(userJwtUserMock);
+
+          const req = mockRequest("Bearer token");
+          const res = mockResponse();
+          const next = mockNext();
+
+          await createAuthContext(bothMethodsAuthOptions)([
+            AuthMethods.API_KEY,
+            AuthMethods.JWT,
+          ])(req, res, next);
+
+          expect(verifyJWT).toBeCalledWith("publicKey", "token", {
+            issuer: "issuer",
+            audience: "audience",
+          });
+          expect(res.status).toHaveBeenCalledTimes(0);
+          expect(res.json).toHaveBeenCalledTimes(0);
+
+          expect(req.context.jwtUser).toMatchObject(userJwtUserMock);
+
+          expect(req.context.authenticated).toStrictEqual(["jwt"]);
+
+          expect(next).toHaveBeenCalledWith();
+        });
+      });
+
+      describe("when jwt verifies incorrectly", () => {
+        it("should not authenticate, should not call next, and it should return 401", async () => {
+          (verifyJWT as jest.Mock).mockResolvedValueOnce(undefined);
+
+          const req = mockRequest("Bearer token");
+          const res = mockResponse();
+          const next = mockNext();
+
+          await createAuthContext(bothMethodsAuthOptions)([
+            AuthMethods.API_KEY,
+            AuthMethods.JWT,
+          ])(req, res, next);
+
+          expect(verifyJWT).toBeCalledWith("publicKey", "token", {
+            issuer: "issuer",
+            audience: "audience",
+          });
+          expect(res.status).toHaveBeenCalledWith(401);
+          expect(res.json).toHaveBeenCalledTimes(1);
+          expect(req.context.jwtUser).toBe(undefined);
+          expect(req.context.authenticated).toEqual([]);
+          expect(next).toHaveBeenCalledTimes(0);
+        });
+      });
+
+      describe("when jwt doesnt exist", () => {
+        it("should not authenticate, should not call next, and it should return 401", async () => {
+          const req = mockRequest(undefined as any);
+          const res = mockResponse();
+          const next = mockNext();
+
+          await createAuthContext(bothMethodsAuthOptions)([
+            AuthMethods.API_KEY,
+            AuthMethods.JWT,
+          ])(req, res, next);
+
+          expect(verifyJWT).toHaveBeenCalledTimes(0);
+          expect(res.status).toHaveBeenCalledWith(401);
+          expect(res.json).toHaveBeenCalledTimes(1);
+          expect(req.context.jwtUser).toBe(undefined);
+          expect(req.context.authenticated).toEqual([]);
+          expect(next).toHaveBeenCalledTimes(0);
+        });
       });
     });
 
-    describe("when jwt verifies incorrectly", () => {
-      it("should not authenticate, should not call next, and it should return 401", async () => {
-        (verifyJWT as jest.Mock).mockResolvedValueOnce(undefined);
+    describe("using jwt method", () => {
+      describe("when jwt verifies correctly", () => {
+        it("should authenticate correctly and call next", async () => {
+          (verifyJWT as jest.Mock).mockResolvedValueOnce(userJwtUserMock);
 
-        const req = mockRequest("Bearer token");
-        const res = mockResponse();
-        const next = mockNext();
+          const req = mockRequest("Bearer token");
+          const res = mockResponse();
+          const next = mockNext();
 
-        await createAuthContext(bothMethodsAuthOptions)([
-          AuthMethods.API_KEY,
-          AuthMethods.JWT,
-        ])(req, res, next);
+          await createAuthContext(bothMethodsAuthOptions)([AuthMethods.JWT])(
+            req,
+            res,
+            next
+          );
 
-        expect(verifyJWT).toBeCalledWith("publicKey", "token", {
-          issuer: "issuer",
-          audience: "audience",
+          expect(verifyJWT).toBeCalledWith("publicKey", "token", {
+            issuer: "issuer",
+            audience: "audience",
+          });
+          expect(res.status).toHaveBeenCalledTimes(0);
+          expect(res.json).toHaveBeenCalledTimes(0);
+          expect(req.context.jwtUser).toMatchObject(userJwtUserMock);
+          expect(req.context.authenticated).toStrictEqual(["jwt"]);
+          expect(next).toHaveBeenCalledWith();
         });
-        expect(res.status).toHaveBeenCalledWith(401);
-        expect(res.json).toHaveBeenCalledTimes(1);
-        expect(req.context.jwtUser).toBe(undefined);
-        expect(req.context.authenticated).toEqual([]);
-        expect(next).toHaveBeenCalledTimes(0);
+      });
+
+      describe("when jwt verifies incorrectly", () => {
+        it("should not authenticate, should not call next, and it should return 401", async () => {
+          (verifyJWT as jest.Mock).mockResolvedValueOnce(undefined);
+
+          const req = mockRequest("Bearer invalidToken");
+          const res = mockResponse();
+          const next = mockNext();
+
+          await createAuthContext(bothMethodsAuthOptions)([AuthMethods.JWT])(
+            req,
+            res,
+            next
+          );
+
+          expect(verifyJWT).toBeCalledWith("publicKey", "invalidToken", {
+            issuer: "issuer",
+            audience: "audience",
+          });
+          expect(res.status).toHaveBeenCalledWith(401);
+          expect(res.json).toHaveBeenCalledTimes(1);
+          expect(req.context.jwtUser).toBe(undefined);
+          expect(req.context.authenticated).toEqual([]);
+          expect(next).toHaveBeenCalledTimes(0);
+        });
+      });
+
+      describe("when api key verifies correctly", () => {
+        it("should authenticate correctly and call next", async () => {
+          const req = mockRequest("token");
+          const res = mockResponse();
+          const next = mockNext();
+
+          await createAuthContext(bothMethodsAuthOptions)([
+            AuthMethods.API_KEY,
+          ])(req, res, next);
+
+          expect(verifyJWT).toHaveBeenCalledTimes(0);
+          expect(res.status).toHaveBeenCalledTimes(0);
+          expect(res.json).toHaveBeenCalledTimes(0);
+
+          expect(req.context.jwtUser).toMatchObject(laraJwtUserMock);
+          expect(req.context.authenticated).toStrictEqual(["api_key"]);
+          expect(next).toHaveBeenCalledWith();
+        });
+      });
+
+      describe("when api key verifies incorrectly", () => {
+        it("should not authenticate, should not call next, and it should return 401", async () => {
+          const req = mockRequest("invalidToken");
+          const res = mockResponse();
+          const next = mockNext();
+
+          await createAuthContext(bothMethodsAuthOptions)([
+            AuthMethods.API_KEY,
+            AuthMethods.JWT,
+          ])(req, res, next);
+
+          expect(verifyJWT).toHaveBeenCalledTimes(0);
+          expect(res.status).toHaveBeenCalledWith(401);
+          expect(res.json).toHaveBeenCalledTimes(1);
+          expect(req.context.jwtUser).toBe(undefined);
+          expect(req.context.authenticated).toEqual([]);
+          expect(next).toHaveBeenCalledTimes(0);
+        });
+      });
+
+      describe("when jwt doesnt exist", () => {
+        it("should not authenticate, should not call next, and it should return 401", async () => {
+          const req = mockRequest("aaa");
+          const res = mockResponse();
+          const next = mockNext();
+
+          await createAuthContext(bothMethodsAuthOptions)([AuthMethods.JWT])(
+            req,
+            res,
+            next
+          );
+
+          expect(verifyJWT).toHaveBeenCalledTimes(0);
+          expect(res.status).toHaveBeenCalledWith(401);
+          expect(res.json).toHaveBeenCalledTimes(1);
+          expect(req.context.jwtUser).toBe(undefined);
+          expect(req.context.authenticated).toEqual([]);
+          expect(next).toHaveBeenCalledTimes(0);
+        });
+      });
+
+      describe("when api key doesnt exist", () => {
+        it("should not authenticate, should not call next, and it should return 401", async () => {
+          const req = mockRequest(undefined as any);
+          const res = mockResponse();
+          const next = mockNext();
+
+          await createAuthContext(bothMethodsAuthOptions)([
+            AuthMethods.API_KEY,
+          ])(req, res, next);
+
+          expect(verifyJWT).toHaveBeenCalledTimes(0);
+          expect(res.status).toHaveBeenCalledWith(401);
+          expect(res.json).toHaveBeenCalledTimes(1);
+          expect(req.context.jwtUser).toBe(undefined);
+          expect(req.context.authenticated).toEqual([]);
+          expect(next).toHaveBeenCalledTimes(0);
+        });
       });
     });
   });

--- a/packages/express/src/middlewares/authenticateUser.ts
+++ b/packages/express/src/middlewares/authenticateUser.ts
@@ -148,7 +148,12 @@ export function createAuthContext<Options extends AuthOptions>(
         );
         next();
       } catch (error: unknown) {
-        logger.info("auth.authWithJwt.invalidJwt", { jwt, error });
+        logger.info("auth.authenticateUser.error", {
+          jwt,
+          token: req.headers.authorization,
+          methods: AuthMethods,
+          error,
+        });
         res.status(401).json(errorView(new UnauthorizedError(authMethods)));
       }
     };

--- a/packages/express/src/test/mocks/authOptionsMocks.ts
+++ b/packages/express/src/test/mocks/authOptionsMocks.ts
@@ -1,0 +1,35 @@
+import {
+  ApiKeyOptions,
+  AuthMethods,
+  BothMethodsOptions,
+  JWTOptions,
+} from "../../middlewares/authenticateUser";
+
+export const jwtAuthOptions = {
+  jwtVerifyOptions: {
+    publicKey: "publicKey",
+    issuer: "issuer",
+    audience: "audience",
+  },
+  types: [AuthMethods.JWT],
+} as any as JWTOptions;
+
+export const verifyOptions = {
+  issuer: "issuer",
+  audience: "audience",
+};
+
+export const apiKeyAuthOptions: ApiKeyOptions = {
+  validApiKeys: ["token", "tooooken"],
+  types: [AuthMethods.API_KEY],
+};
+
+export const bothMethodsAuthOptions: BothMethodsOptions = {
+  jwtVerifyOptions: {
+    publicKey: "publicKey",
+    issuer: "issuer",
+    audience: "audience",
+  },
+  validApiKeys: ["token", "tooooken"],
+  types: [AuthMethods.API_KEY, AuthMethods.JWT],
+};

--- a/packages/express/src/test/mocks/expressMocks.ts
+++ b/packages/express/src/test/mocks/expressMocks.ts
@@ -1,0 +1,17 @@
+import { GenericRequest } from "../../types/GenericRequest";
+
+export const mockRequest = (authorization: string): GenericRequest => {
+  return {
+    headers: { authorization },
+    context: { jwtUser: undefined, authenticated: [] },
+  } as any as GenericRequest;
+};
+
+export const mockResponse = () => {
+  const res = {} as any;
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+export const mockNext = () => jest.fn();

--- a/packages/express/src/test/mocks/jwtUserMocks.ts
+++ b/packages/express/src/test/mocks/jwtUserMocks.ts
@@ -1,0 +1,17 @@
+import { JWTUser } from "@alanszp/jwt";
+
+export const userJwtUserMock: JWTUser = {
+  id: "1",
+  employeeReference: "1",
+  organizationReference: "test",
+  roles: [],
+  permissions: [],
+};
+
+export const laraJwtUserMock: JWTUser = {
+  id: "0",
+  employeeReference: "0",
+  organizationReference: "lara",
+  roles: [],
+  permissions: [],
+};

--- a/packages/express/src/test/setup.test.ts
+++ b/packages/express/src/test/setup.test.ts
@@ -1,0 +1,15 @@
+import { now } from "../helpers/now";
+
+jest.mock("@/helpers/now");
+
+describe("Timezones", () => {
+  it("should always be UTC", () => {
+    expect(new Date().getTimezoneOffset()).toBe(0);
+  });
+
+  it("now() is mocked", () => {
+    (now as jest.Mock).mockReturnValue(new Date("2021-01-01T12:30:43"));
+
+    expect(now()).toEqual(new Date("2021-01-01T12:30:43"));
+  });
+});

--- a/packages/express/src/test/setup.ts
+++ b/packages/express/src/test/setup.ts
@@ -1,0 +1,3 @@
+import { config } from "dotenv";
+
+config({ path: ".env.test" });

--- a/packages/express/src/types/AuthMethod.ts
+++ b/packages/express/src/types/AuthMethod.ts
@@ -21,4 +21,7 @@ type OverridableStringUnion<
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface AuthMethodsOverride {}
 
-export type AuthMethod = OverridableStringUnion<"jwt", AuthMethodsOverride>;
+export type AuthMethod = OverridableStringUnion<
+  "jwt" | "api_key",
+  AuthMethodsOverride
+>;

--- a/packages/express/tsconfig.json
+++ b/packages/express/tsconfig.json
@@ -4,12 +4,15 @@
     "outDir": "dist",
     "module": "commonjs",
     "target": "es6",
-    "types": ["node"],
+    "types": ["jest", "node"],
     "esModuleInterop": true,
     "sourceMap": true,
 
     "alwaysStrict": true,
     "strictNullChecks": true
   },
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
+  "paths": {
+    "@/*": ["src/*"]
+  }
 }


### PR DESCRIPTION
modifica el middleware de autenticacion para permitir que un endpoint:

pueda autenticar por jwt,
pueda autenticar por api_key,
pueda autenticar por ambas (en el caso de que reciba tanto eventos como requests)