### PR TITLE
[FIX] Context middleware breaks when there's no body

### DIFF
--- a/packages/eventbridge-client/src/helpers/mapLaraEventToAWSEvent.ts
+++ b/packages/eventbridge-client/src/helpers/mapLaraEventToAWSEvent.ts
@@ -19,7 +19,7 @@ export function mapLaraEventToAWSEvent(
   try {
     return {
       DetailType: topic,
-      Detail: JSON.stringify({ ...body, lch }),
+      Detail: JSON.stringify({ ...body, lch, lid }), // lid is included here since the TraceHeader is not sent to the targets by aws
       Source: `${env}.lara.${appName}`,
       EventBusName: bus,
       Time: new Date(),

--- a/packages/express/src/middlewares/createContext.test.ts
+++ b/packages/express/src/middlewares/createContext.test.ts
@@ -1,0 +1,85 @@
+import { createContext } from "./createContext";
+import { SharedContext } from "@alanszp/shared-context";
+import { createMockLogger } from "@alanszp/logger";
+import { createAuditLogger } from "@alanszp/audit";
+import {
+  mockNext,
+  mockRequest,
+  mockRequestWithBody,
+  mockResponse,
+} from "../test/mocks/expressMocks";
+import { appIdentifier } from "../../dist/helpers/appIdentifier";
+jest.mock("@alanszp/shared-context");
+
+const logger = createMockLogger({});
+const sharedContext = new SharedContext();
+const lifecycleId = "123";
+const lifecycleChain = "node:test";
+
+describe("CreateContext", () => {
+  describe("when has lifecycle headers", () => {
+    beforeAll(() => {
+      (SharedContext as jest.Mock).mockClear();
+    });
+    it("should get lifecycle identifiers from there", () => {
+      const middleware = createContext(
+        sharedContext,
+        logger,
+        createAuditLogger(logger)
+      );
+
+      middleware(
+        mockRequest("authToken", {
+          "x-lifecycle-chain": lifecycleChain,
+          "x-lifecycle-id": lifecycleId,
+        }),
+        mockResponse(),
+        mockNext()
+      );
+
+      expect(sharedContext.run).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          lifecycleId,
+          lifecycleChain: `${lifecycleChain},${appIdentifier()}`,
+        })
+      );
+    });
+  });
+
+  describe("when doesn't have lifecycle headers", () => {
+    beforeAll(() => {
+      (SharedContext as jest.Mock).mockClear();
+    });
+    it("should get lifecycle identifiers from body.detail", () => {
+      const middleware = createContext(
+        sharedContext,
+        logger,
+        createAuditLogger(logger)
+      );
+
+      middleware(
+        mockRequestWithBody(
+          "authToken",
+          {},
+          {
+            detail: {
+              lch: lifecycleChain,
+              lid: lifecycleId,
+            },
+          }
+        ),
+        mockResponse(),
+        mockNext()
+      );
+
+      expect(sharedContext.run).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          lifecycleId,
+          lifecycleChain: `${lifecycleChain},${appIdentifier()}`,
+        })
+      );
+    });
+  });
+});

--- a/packages/express/src/middlewares/createContext.ts
+++ b/packages/express/src/middlewares/createContext.ts
@@ -16,13 +16,11 @@ export function createContext(
     req.context = req.context || {};
 
     const receivedChain =
-      req.header("x-lifecycle-chain") || req.body?.Detail?.lch;
+      req.header("x-lifecycle-chain") || req.body?.detail?.lch;
     const lifecycleChain = compact([receivedChain, appIdentifier()]).join(",");
 
     const lifecycleId =
-      req.headers["x-lifecycle-id"]?.toString() ||
-      req.body?.Detail?.lid ||
-      cuid();
+      req.header("x-lifecycle-id") || req.body?.detail?.lid || cuid();
 
     const contextId = cuid();
 

--- a/packages/express/src/middlewares/createContext.ts
+++ b/packages/express/src/middlewares/createContext.ts
@@ -15,10 +15,14 @@ export function createContext(
   return (req: GenericRequest, _res: Response, next: NextFunction): void => {
     req.context = req.context || {};
 
-    const receivedChain = req.header("x-lifecycle-chain") || req.body["Detail"]?.lch;
+    const receivedChain =
+      req.header("x-lifecycle-chain") || req.body?.Detail?.lch;
     const lifecycleChain = compact([receivedChain, appIdentifier()]).join(",");
 
-    const lifecycleId = req.headers["x-lifecycle-id"]?.toString() || req.body["TraceHeader"] || cuid();
+    const lifecycleId =
+      req.headers["x-lifecycle-id"]?.toString() ||
+      req.body?.Detail?.lid ||
+      cuid();
 
     const contextId = cuid();
 

--- a/packages/express/src/middlewares/returnInternalServerError.ts
+++ b/packages/express/src/middlewares/returnInternalServerError.ts
@@ -2,13 +2,15 @@ import { ErrorRequestHandler, NextFunction, Response } from "express";
 import { InternalServerError } from "@alanszp/errors";
 import { errorView } from "../views/errorView";
 import { GenericRequest } from "../types/GenericRequest";
+import { ILogger } from "@alanszp/logger";
 
-export const returnInternalServerError: ErrorRequestHandler = (
-  error: unknown,
-  req: GenericRequest,
-  res: Response,
-  _next: NextFunction
-) => {
-  res.status(500).json(errorView(new InternalServerError(error)));
-  req.context?.log.error("error_to_client", { error });
-};
+export type GetInternalServerErrorMiddleware = (
+  getLogger: () => ILogger
+) => ErrorRequestHandler;
+
+export const returnInternalServerError: GetInternalServerErrorMiddleware =
+  (getLogger: () => ILogger) =>
+  (error: unknown, req: GenericRequest, res: Response, _next: NextFunction) => {
+    res.status(500).json(errorView(new InternalServerError(error)));
+    getLogger().error("error_to_client", { error });
+  };

--- a/packages/express/src/test/mocks/expressMocks.ts
+++ b/packages/express/src/test/mocks/expressMocks.ts
@@ -1,9 +1,25 @@
 import { GenericRequest } from "../../types/GenericRequest";
 
-export const mockRequest = (authorization: string): GenericRequest => {
+export const mockRequest = (
+  authorization: string,
+  otherHeaders?: Record<string, unknown>
+): GenericRequest => {
+  const headers = { authorization, ...otherHeaders };
   return {
-    headers: { authorization },
+    headers,
     context: { jwtUser: undefined, authenticated: [] },
+    header: (name: string) => headers[name],
+  } as any as GenericRequest;
+};
+
+export const mockRequestWithBody = (
+  authorization: string,
+  otherHeaders?: Record<string, unknown>,
+  body: Record<string, unknown> = {}
+): GenericRequest => {
+  return {
+    ...mockRequest(authorization, otherHeaders),
+    body,
   } as any as GenericRequest;
 };
 


### PR DESCRIPTION
```
Important
The trace header is not available on the event that's delivered to the invocation target.
```

https://docs.aws.amazon.com/eventbridge/latest/userguide/user-guide.pdf p. 107