### PR TITLE
fix lara service account getting out of new permissions endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # SO files
 .DS_Store
+
+# VSCode
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Change `@alanszp/express`: Add changes to `auditMiddleware` to support audit changes.
 - Change `@alanszp/serverless`: Add changes to `withAuditLogMiddleware` to support audit changes.
 - Change `@alanszp/jwt`: Add defaults in `JWTUser` for originalFields. If not given by the jwt, will use the actual ones.
+- Change `@alanszp/jwt`: Fix `isImpersonating` logic.
+- Add `@alanszp/jwt`: Add `isServiceAccount` method to `JWTUser`.
 - Change `@alanszp/express`: Add changes to `hasPermission`, `hasSomePermission` and `hasEveryPermission` to support services account logs and remove old optional param of `oldRoleCodes` that bring an unexpected behavior.
 - Upgrade `braces` for security vulnerabilities
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v15.0.4
+
+- Change `@alanszp/audit`: Add new keys for better understanding if access was impersonated.
+- Change `@alanszp/express`: Add changes to `auditMiddleware` to support audit changes.
+- Change `@alanszp/serverless`: Add changes to `withAuditLogMiddleware` to support audit changes.
+- Change `@alanszp/jwt`: Add defaults in `JWTUser` for originalFields. If not given by the jwt, will use the actual ones.
+- Change `@alanszp/express`: Add changes to `hasPermission`, `hasSomePermission` and `hasEveryPermission` to support services account logs and remove old optional param of `oldRoleCodes` that bring an unexpected behavior.
+- Upgrade `braces` for security vulnerabilities
+
 ## v15.0.3
 
 - Change `@alanszp/jwt`: Add role reference to jwt

--- a/packages/audit/src/interfaces.ts
+++ b/packages/audit/src/interfaces.ts
@@ -1,7 +1,9 @@
 export interface AuditBody {
   // Who
-  actorRef: string;
-  orgRef: string;
+  actorRef: string; // Real user ID
+  impersonatedRef?: string; // Impersonated user ID. If no impersonating, it will be undefined
+  orgRef: string; // Org that was accessed
+  originalOrgRef: string; // Original org from the real user. If no impersonating, it will be the same as orgRef
 
   // Where (it can be an array since the request can jump between nodes, and http keeps record of their IPs)
   ip: string | string[];

--- a/packages/audit/src/interfaces.ts
+++ b/packages/audit/src/interfaces.ts
@@ -1,9 +1,10 @@
 export interface AuditBody {
   // Who
   actorRef: string; // Real user ID
-  impersonatedRef?: string; // Impersonated user ID. If no impersonating, it will be undefined
-  orgRef: string; // Org that was accessed
-  originalOrgRef: string; // Original org from the real user. If no impersonating, it will be the same as orgRef
+  orgRef: string; // Original org from the real user.
+
+  impersonatedActorRef?: string; // Impersonated user ID. If no impersonating, it will be undefined
+  impersonatedOrgRef?: string; // Org that was accessed. If no impersonating, it will be the same as orgRef
 
   // Where (it can be an array since the request can jump between nodes, and http keeps record of their IPs)
   ip: string | string[];

--- a/packages/audit/src/interfaces.ts
+++ b/packages/audit/src/interfaces.ts
@@ -4,7 +4,7 @@ export interface AuditBody {
   orgRef: string; // Original org from the real user.
 
   impersonatedActorRef?: string; // Impersonated user ID. If no impersonating, it will be undefined
-  impersonatedOrgRef?: string; // Org that was accessed. If no impersonating, it will be the same as orgRef
+  impersonatedOrgRef?: string; // Org that was accessed. If no impersonating, it will be undefined
 
   // Where (it can be an array since the request can jump between nodes, and http keeps record of their IPs)
   ip: string | string[];

--- a/packages/express/src/middlewares/auditLog.ts
+++ b/packages/express/src/middlewares/auditLog.ts
@@ -33,8 +33,6 @@ export function auditLog(action: string, bodyModifier?: AuditBodyModifier) {
           partialBody.impersonatedOrgRef = jwtUser.isImpersonating()
             ? jwtUser.organizationReference
             : undefined;
-          jwtUser.originalOrganizationReference ??
-            jwtUser.organizationReference;
           partialBody.actorRef = jwtUser.originalId ?? jwtUser.id;
           partialBody.impersonatedActorRef = jwtUser.isImpersonating()
             ? jwtUser.id

--- a/packages/express/src/middlewares/auditLog.ts
+++ b/packages/express/src/middlewares/auditLog.ts
@@ -27,12 +27,16 @@ export function auditLog(action: string, bodyModifier?: AuditBodyModifier) {
 
         const jwtUser = req.context.jwtUser;
         if (jwtUser) {
-          partialBody.orgRef = jwtUser.organizationReference;
-          partialBody.originalOrgRef =
+          partialBody.orgRef =
             jwtUser.originalOrganizationReference ??
             jwtUser.organizationReference;
+          partialBody.impersonatedOrgRef = jwtUser.isImpersonating()
+            ? jwtUser.organizationReference
+            : undefined;
+          jwtUser.originalOrganizationReference ??
+            jwtUser.organizationReference;
           partialBody.actorRef = jwtUser.originalId ?? jwtUser.id;
-          partialBody.impersonatedRef = jwtUser.isImpersonating()
+          partialBody.impersonatedActorRef = jwtUser.isImpersonating()
             ? jwtUser.id
             : undefined;
         }

--- a/packages/express/src/middlewares/auditLog.ts
+++ b/packages/express/src/middlewares/auditLog.ts
@@ -25,9 +25,16 @@ export function auditLog(action: string, bodyModifier?: AuditBodyModifier) {
           ? await Promise.resolve(bodyModifier(req, res))
           : ({} as Partial<AuditBody>);
 
-        if (req.context.jwtUser) {
-          partialBody.orgRef = req.context.jwtUser.organizationReference;
-          partialBody.actorRef = req.context.jwtUser.id;
+        const jwtUser = req.context.jwtUser;
+        if (jwtUser) {
+          partialBody.orgRef = jwtUser.organizationReference;
+          partialBody.originalOrgRef =
+            jwtUser.originalOrganizationReference ??
+            jwtUser.organizationReference;
+          partialBody.actorRef = jwtUser.originalId ?? jwtUser.id;
+          partialBody.impersonatedRef = jwtUser.isImpersonating()
+            ? jwtUser.id
+            : undefined;
         }
 
         partialBody.ip = getIp(req) || "no-ip";

--- a/packages/express/src/middlewares/hasPermissions.ts
+++ b/packages/express/src/middlewares/hasPermissions.ts
@@ -8,15 +8,7 @@ function response401(res: Response): void {
   res.status(401).json(render401Error(["jwt"]));
 }
 
-// To check if it's not impersonating and is Lara Service Account.
-// TODO: Remove when we have service accounts.
-function checkForServiceAccount(jwtUser: JWTUser) {
-  return (
-    !jwtUser.isImpersonating() &&
-    jwtUser.originalEmployeeReference === "0" &&
-    jwtUser.originalOrganizationReference === "lara"
-  );
-}
+function checkForServiceAccount(jwtUser: JWTUser) {}
 
 /**
  * Check if the jwtUser has a single permission
@@ -31,7 +23,8 @@ export function hasPermission(permission: string) {
         return response401(res);
       }
 
-      if (checkForServiceAccount(jwtUser)) {
+      // TODO: Remove when we have service accounts, SA will have it's own permissions so this will not be needed.
+      if (jwtUser.isServiceAccount()) {
         return hasRoles(["admin"])(req, res, next);
       }
 
@@ -55,7 +48,9 @@ export function hasSomePermission(permissions: string[]) {
       if (!jwtUser) {
         return response401(res);
       }
-      if (checkForServiceAccount(jwtUser)) {
+
+      // TODO: Remove when we have service accounts, SA will have it's own permissions so this will not be needed.
+      if (jwtUser.isServiceAccount()) {
         return hasRoles(["admin"])(req, res, next);
       }
 
@@ -80,7 +75,8 @@ export function hasEveryPermission(permissions: string[]) {
         return response401(res);
       }
 
-      if (checkForServiceAccount(jwtUser)) {
+      // TODO: Remove when we have service accounts, SA will have it's own permissions so this will not be needed.
+      if (jwtUser.isServiceAccount()) {
         return hasRoles(["admin"])(req, res, next);
       }
 

--- a/packages/express/src/middlewares/hasPermissions.ts
+++ b/packages/express/src/middlewares/hasPermissions.ts
@@ -2,9 +2,20 @@ import { NextFunction, Response } from "express";
 import { GenericRequest } from "../types/GenericRequest";
 import { hasRoles } from "./hasRoles";
 import { render401Error } from "../helpers/renderErrorJson";
+import { JWTUser } from "@alanszp/jwt";
 
 function response401(res: Response): void {
   res.status(401).json(render401Error(["jwt"]));
+}
+
+// To check if it's not impersonating and is Lara Service Account.
+// TODO: Remove when we have service accounts.
+function checkForServiceAccount(jwtUser: JWTUser) {
+  return (
+    !jwtUser.isImpersonating() &&
+    jwtUser.originalEmployeeReference === "0" &&
+    jwtUser.originalOrganizationReference === "lara"
+  );
 }
 
 /**
@@ -20,12 +31,7 @@ export function hasPermission(permission: string) {
         return response401(res);
       }
 
-      // To check if it's not impersonating and is Lara Service Account.
-      // TODO: Remove when we have service accounts.
-      if (
-        jwtUser.employeeReference === "0" &&
-        jwtUser.originalOrganizationReference === "lara"
-      ) {
+      if (checkForServiceAccount(jwtUser)) {
         return hasRoles(["admin"])(req, res, next);
       }
 
@@ -49,13 +55,7 @@ export function hasSomePermission(permissions: string[]) {
       if (!jwtUser) {
         return response401(res);
       }
-
-      // To check if it's not impersonating and is Lara Service Account.
-      // TODO: Remove when we have service accounts.
-      if (
-        jwtUser.employeeReference === "0" &&
-        jwtUser.originalOrganizationReference === "lara"
-      ) {
+      if (checkForServiceAccount(jwtUser)) {
         return hasRoles(["admin"])(req, res, next);
       }
 
@@ -80,12 +80,7 @@ export function hasEveryPermission(permissions: string[]) {
         return response401(res);
       }
 
-      // To check if it's not impersonating and is Lara Service Account.
-      // TODO: Remove when we have service accounts.
-      if (
-        jwtUser.employeeReference === "0" &&
-        jwtUser.originalOrganizationReference === "lara"
-      ) {
+      if (checkForServiceAccount(jwtUser)) {
         return hasRoles(["admin"])(req, res, next);
       }
 

--- a/packages/express/src/middlewares/hasPermissions.ts
+++ b/packages/express/src/middlewares/hasPermissions.ts
@@ -2,13 +2,10 @@ import { NextFunction, Response } from "express";
 import { GenericRequest } from "../types/GenericRequest";
 import { hasRoles } from "./hasRoles";
 import { render401Error } from "../helpers/renderErrorJson";
-import { JWTUser } from "@alanszp/jwt";
 
 function response401(res: Response): void {
   res.status(401).json(render401Error(["jwt"]));
 }
-
-function checkForServiceAccount(jwtUser: JWTUser) {}
 
 /**
  * Check if the jwtUser has a single permission

--- a/packages/express/src/middlewares/hasPermissions.ts
+++ b/packages/express/src/middlewares/hasPermissions.ts
@@ -26,7 +26,7 @@ export function hasPermission(permission: string) {
         jwtUser.employeeReference === "0" &&
         jwtUser.originalOrganizationReference === "lara"
       ) {
-        return next();
+        return hasRoles(["admin"])(req, res, next);
       }
 
       await jwtUser.validatePermission(permission);

--- a/packages/express/src/middlewares/hasPermissions.ts
+++ b/packages/express/src/middlewares/hasPermissions.ts
@@ -42,10 +42,7 @@ export function hasPermission(permission: string) {
  * If not, check if the jwtUser has the required roles (to maintain backwards compatibility)
  * When neither permissions nor roles requirements are met, throw a NoPermissionError
  */
-export function hasSomePermission(
-  permissions: string[],
-  oldRoleCodes?: string | string[]
-) {
+export function hasSomePermission(permissions: string[]) {
   return async (req: GenericRequest, res: Response, next: NextFunction) => {
     try {
       const { jwtUser } = req.context;
@@ -53,12 +50,18 @@ export function hasSomePermission(
         return response401(res);
       }
 
+      // To check if it's not impersonating and is Lara Service Account.
+      // TODO: Remove when we have service accounts.
+      if (
+        jwtUser.employeeReference === "0" &&
+        jwtUser.originalOrganizationReference === "lara"
+      ) {
+        return hasRoles(["admin"])(req, res, next);
+      }
+
       await jwtUser.validateSomePermission(permissions);
       next();
     } catch (error: unknown) {
-      if (oldRoleCodes) {
-        return hasRoles(oldRoleCodes)(req, res, next);
-      }
       next(error);
     }
   };
@@ -69,10 +72,7 @@ export function hasSomePermission(
  * If not, check if the jwtUser has the required roles (to maintain backwards compatibility)
  * When neither permissions nor roles requirements are met, throw a NoPermissionError
  */
-export function hasEveryPermission(
-  permissions: string[],
-  oldRoleCodes?: string | string[]
-) {
+export function hasEveryPermission(permissions: string[]) {
   return async (req: GenericRequest, res: Response, next: NextFunction) => {
     try {
       const { jwtUser } = req.context;
@@ -80,12 +80,18 @@ export function hasEveryPermission(
         return response401(res);
       }
 
+      // To check if it's not impersonating and is Lara Service Account.
+      // TODO: Remove when we have service accounts.
+      if (
+        jwtUser.employeeReference === "0" &&
+        jwtUser.originalOrganizationReference === "lara"
+      ) {
+        return hasRoles(["admin"])(req, res, next);
+      }
+
       await jwtUser.validateEveryPermission(permissions);
       next();
     } catch (error: unknown) {
-      if (oldRoleCodes) {
-        return hasRoles(oldRoleCodes)(req, res, next);
-      }
       next(error);
     }
   };

--- a/packages/jwt/src/JWTUser.ts
+++ b/packages/jwt/src/JWTUser.ts
@@ -95,9 +95,9 @@ export class JWTUser implements IJWTUser {
       roleReferences: payload.rl,
       permissions: payload.prms,
       segmentReference: payload.seg || null,
-      originalOrganizationReference: payload.oorg,
-      originalId: payload.osub,
-      originalEmployeeReference: payload.oref,
+      originalOrganizationReference: payload.oorg ?? payload.org,
+      originalId: payload.osub ?? payload.sub,
+      originalEmployeeReference: payload.oref ?? payload.ref,
       expirationTime: payload.exp,
     });
   }

--- a/packages/jwt/src/JWTUser.ts
+++ b/packages/jwt/src/JWTUser.ts
@@ -263,9 +263,16 @@ export class JWTUser implements IJWTUser {
   }
 
   public isImpersonating(): boolean {
+    return this.id !== this.originalId;
+  }
+
+  // To check if it's not impersonating and is Lara Service Account. This should be change to check the
+  // JWT type instead.
+  public isServiceAccount(): boolean {
     return (
-      this.organizationReference !== this.originalEmployeeReference ||
-      this.id !== this.originalId
+      !this.isImpersonating() &&
+      this.originalEmployeeReference === "0" &&
+      this.originalOrganizationReference === "lara"
     );
   }
 }

--- a/packages/serverless/src/middlewares/withAuditLogMiddleware.ts
+++ b/packages/serverless/src/middlewares/withAuditLogMiddleware.ts
@@ -11,11 +11,14 @@ export function withAuditLogMiddleware<TEvent, TResult>(
   return {
     after: (_): void => {
       const audit = sharedContext.getAudit();
+      const originalOrgRef =
+        customAuditValues?.originalOrgRef ?? customAuditValues?.orgRef;
 
       audit &&
         audit.log({
           succeed: true,
           actorRef: AUTOMATIC_ACTION_ACTOR_REF,
+          originalOrgRef,
           ...customAuditValues,
         });
     },

--- a/packages/serverless/src/middlewares/withAuditLogMiddleware.ts
+++ b/packages/serverless/src/middlewares/withAuditLogMiddleware.ts
@@ -11,14 +11,11 @@ export function withAuditLogMiddleware<TEvent, TResult>(
   return {
     after: (_): void => {
       const audit = sharedContext.getAudit();
-      const originalOrgRef =
-        customAuditValues?.originalOrgRef ?? customAuditValues?.orgRef;
 
       audit &&
         audit.log({
           succeed: true,
           actorRef: AUTOMATIC_ACTION_ACTOR_REF,
-          originalOrgRef,
           ...customAuditValues,
         });
     },


### PR DESCRIPTION
Hago este PR porque con los nuevos permisos que esta implementando @fkmurphy, vamos a dejar afuera a los "service accounts" que tienen un token viejo:

El payload del de stg se ve asi:
```
{
  "sub": "0",
  "ref": "0",
  "org": "lara",
  "rls": [
    "admin"
  ],
  "prms": [],
  "seg": null,
  "iat": 1702412074,
  "iss": "long:1",
  "aud": "web",
  "exp": 1733969674
}
```

Aparte, habia un problema de logica con la logica anterior de `oldRoleCodes`.
Si realmente se pasaba ese param (cosa que no lo estabamos haciendo), ibamos a tener un caso malo:
- La persona es HRBP pero le quitan cierto permiso de HRBP normal
- el endpoint se configura como `hasPermissions('permiso_que_se_le_saco`, ['hrbp'])`
- La persona entra y va a authenticarse correctametne en el endpoint ya que si bien no tiene el permiso, sigue siendo HRBP.

## SOLUCION  

Es por eso que hago 2 cosas:
- Remuevo el checkeo de los oldRoleCodes --> Esto produce que los usuarios loggeados no tengan acceso al endpoint apenas subimos el nuevo permiso, tenemos que espera 1 dia a deployar el check del back, ya que como max duran 1 dia la sesion.
- Al JWTUser le estoy poniendo los originals porque estos tokens no lo tienen seteado. Ojo que tal vez podriamos regenerar los tokens a la nueva Version y evitarnos esto.


## Aparte

- Soluciono un bug de seguridad
- Agrgo al audit log mejor chequeos de quien hizo la accion