### PR TITLE
15.0.5 :: Express :: Support promises for inputConstructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v15.0.5
+
+- Change `@alanszp/express`: Support promises on inputConstructor in the buildAuthEndpoint method
+
 ## v15.0.4
 
 - Change `@alanszp/audit`: Add new keys for better understanding if access was impersonated.

--- a/packages/express/src/endpoints/BaseApi.ts
+++ b/packages/express/src/endpoints/BaseApi.ts
@@ -28,7 +28,7 @@ export type BuildAuthEndpointOptions<
     | undefined
 > = {
   request: AuthRequest;
-  inputConstructor: (jwtUser: JWTUser) => Input;
+  inputConstructor: (jwtUser: JWTUser) => Promise<Input> | Input;
   command: (
     input: Input
   ) => Promise<CommandReturnType & Partial<Viewable<ViewReturnType>>>;
@@ -71,7 +71,7 @@ export class BaseApi extends Controller {
     const baseLog = `${snakeCase(path)}.${snakeCase(method)}`;
     const logger = getLogger();
 
-    const input = inputConstructor(user);
+    const input = await inputConstructor(user);
 
     logger.info(`${baseLog}.controller.starting`, { input });
 


### PR DESCRIPTION
Necesitaba usar una promise en el inputConstructor del method buildAuthEndpoint del BaseApi de TSOA

Donde se usa? Aca! https://github.com/meetlara/dashboard-service/pull/1446/files#diff-1f97c19ef96566ba5fd91c88877b77edc4b300a01baeba153684e385eba13c80R50