### PR TITLE
add better opts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v16.4.2
+
+- Fix `@alanszp/queue`: Worker: Change log names. We are adding queue name to log so we can easily differentiate and take accurate metrics.
+- Fix `@alanszp/queue`: Worker: handleJobError and handleJobFailed will not log error if defined.
+
 ## v16.4.1
 
 - Fix `@alanszp/nunjucks-utils`: Fix safePercentage rounding numbers below 0 and formatNumber not rendering string numerics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix `@alanszp/queue`: Worker: Change log names. We are adding queue name to log so we can easily differentiate and take accurate metrics.
 - Fix `@alanszp/queue`: Worker: handleJobError and handleJobFailed will not log error if defined.
+- Fix `@alanszp/queue`: Worker: If handleJobError and handleJobFailed are not defined, we will log as error just the last attempt of that worker, else we will log it as warn.
 
 ## v16.4.1
 

--- a/packages/queue/src/worker/worker.ts
+++ b/packages/queue/src/worker/worker.ts
@@ -118,25 +118,15 @@ abstract class Worker<Data = JobData, ReturnValue = unknown> {
     if (this.handleJobFailed) {
       await this.handleJobFailed(job, error, this.isLastAttempt(job));
     } else {
-      if (isLastAttempt) {
-        this.getLogger().error(
-          `worker.job.failed.${snakeCase(this.queueFullName)}`,
-          {
-            queue: this.queueFullName,
-            job,
-            error,
-          }
-        );
-      } else {
-        this.getLogger().warn(
-          `worker.job.failed.${snakeCase(this.queueFullName)}`,
-          {
-            queue: this.queueFullName,
-            job,
-            error,
-          }
-        );
-      }
+      const logLevel = isLastAttempt ? ("error" as const) : ("warn" as const);
+      this.getLogger()[logLevel](
+        `worker.job.failed.${snakeCase(this.queueFullName)}`,
+        {
+          queue: this.queueFullName,
+          job,
+          error,
+        }
+      );
     }
   }
 
@@ -172,29 +162,21 @@ abstract class Worker<Data = JobData, ReturnValue = unknown> {
   }
 
   async run(): Promise<void> {
+    const logger = this.getLogger();
     try {
-      this.getLogger().info(
-        `worker.run.starting.${snakeCase(this.queueFullName)}`,
-        {
-          queue: this.queueFullName,
-        }
-      );
+      logger.info(`worker.run.starting.${snakeCase(this.queueFullName)}`, {
+        queue: this.queueFullName,
+      });
 
       await this.worker.run();
-      this.getLogger().info(
-        `worker.run.started.${snakeCase(this.queueFullName)}`,
-        {
-          queue: this.queueFullName,
-        }
-      );
+      logger.info(`worker.run.started.${snakeCase(this.queueFullName)}`, {
+        queue: this.queueFullName,
+      });
     } catch (error: unknown) {
-      this.getLogger().error(
-        `worker.run.error.${snakeCase(this.queueFullName)}`,
-        {
-          queue: this.queueFullName,
-          error,
-        }
-      );
+      logger.error(`worker.run.error.${snakeCase(this.queueFullName)}`, {
+        queue: this.queueFullName,
+        error,
+      });
       throw error;
     }
   }


### PR DESCRIPTION

- Fix `@alanszp/queue`: Worker: Change log names. We are adding queue name to log so we can easily differentiate and take accurate metrics.
- Fix `@alanszp/queue`: Worker: handleJobError and handleJobFailed will not log error if defined.
